### PR TITLE
Database initialization

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,26 @@
 # Spring Boot - Final Project
 
+## Development Instructions
+
+### Database initialization
+The following commands will create a mysql docker container on your system. To use this, you must have docker installed on your system.
+
+Create the container (run from the root of this repo):
+```shell
+docker-compose -f "./docker/docker-compose.yml" -p "todo-application-mysql" up -d
+```
+
+This will create and launch a docker container using the mysql image and run it on `localhost:3606`. This will also initialize the database tables for it.
+
+To remove the container run the following commands (if these commands do not work, ensure that the name of the created container is todo-application-mysql (`-db-1` is appended to the end)):
+```shell
+docker stop todo-application-mysql-db-1
+```
+
+```shell
+docker rm -v todo-application-mysql-db-1
+```
+
 ## Introduction: 
 Life gets hectic, and we get it. Balancing your personal tasks, collaborating with others, and keeping up with shared responsibilities can be a juggling act. That's why we've created a task management and collaboration app that's designed to simplify your daily life. Whether you're a student sharing a space with roommates, part of a team managing projects, or just looking for a way to stay organized, our app has got you covered.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  db:
+    image: mysql:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: admin
+      MYSQL_DATABASE: todo
+      MYSQL_USER: application
+      MYSQL_PASSWORD: admin
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "3306:3306"

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,40 @@
+CREATE TABLE lists (
+    list_id int NOT NULL AUTO_INCREMENT,
+    name varchar(255) NOT NULL,
+    description varchar(255),
+
+    PRIMARY KEY (list_id)
+);
+
+CREATE TABLE tasks (
+    task_id int NOT NULL AUTO_INCREMENT,
+    name varchar(255) NOT NULL,
+    due_date DATE,
+    completed BOOLEAN NOT NULL,
+    list_id int,
+    list_order int,
+
+    PRIMARY KEY (task_id),
+    FOREIGN KEY (list_id) REFERENCES lists(list_id)
+);
+
+CREATE TABLE users (
+    user_id int NOT NULL AUTO_INCREMENT,
+    username varchar(255) NOT NULL,
+    password varchar(255) NOT NULL,
+
+    PRIMARY KEY (user_id)
+);
+
+CREATE TABLE user_lists (
+    id int NOT NULL AUTO_INCREMENT,
+    user_id int NOT NULL,
+    list_id int NOT NULL,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    FOREIGN KEY (list_id) REFERENCES lists(list_id)
+);
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,20 @@
 			<version>1.18.22</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
+			<version>2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.33</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/todolist/enterprise/TaskController.java
+++ b/src/main/java/com/todolist/enterprise/TaskController.java
@@ -1,12 +1,19 @@
 package com.todolist.enterprise;
 import org.springframework.stereotype.Controller;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.todolist.enterprise.dto.Task;
+import com.todolist.enterprise.service.ITodoService;
+
 
 @Controller
 public class TaskController {
+
+    @Autowired
+    private ITodoService todoService;
 
     @RequestMapping("/")
     public String index() {
@@ -14,7 +21,13 @@ public class TaskController {
     }
 
     @GetMapping("/task/{id}")
-    public ResponseEntity getTaskById(@PathVariable("id") String id) {
-        return new ResponseEntity(HttpStatus.OK);
+    public ResponseEntity<Task> getTaskById(@PathVariable("id") int id) {
+        try {
+            Task foundTask = todoService.getTaskById(id);
+            return new ResponseEntity<Task>(foundTask, HttpStatus.OK);
+        }
+        catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/todolist/enterprise/dao/TaskRepository.java
+++ b/src/main/java/com/todolist/enterprise/dao/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.todolist.enterprise.dao;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.repository.CrudRepository;
+
+import com.todolist.enterprise.dto.Task;
+
+@Profile("!test")
+public interface TaskRepository extends CrudRepository<Task, Integer>{
+    
+}

--- a/src/main/java/com/todolist/enterprise/dto/List.java
+++ b/src/main/java/com/todolist/enterprise/dto/List.java
@@ -1,8 +1,0 @@
-package com.todolist.enterprise.dto;
-import lombok.Data;
-
-public @Data class List {
-    private int listId;
-    private String name;
-    private String description;
-}

--- a/src/main/java/com/todolist/enterprise/dto/Task.java
+++ b/src/main/java/com/todolist/enterprise/dto/Task.java
@@ -1,13 +1,36 @@
 package com.todolist.enterprise.dto;
 
 import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Data;
 
+@Entity
+@Table(name = "tasks")
 public @Data class Task {
-    private int taskId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_id")
+    private Integer taskId;
+    
+    @Column(nullable = false)
     private String name;
+
+    @Column(name = "due_date")
     private Date dueDate;
+
+    @Column(nullable = false)
     private boolean completed;
-    private int listId;
-    private int listOrder;
+
+    @Column(name = "list_id")
+    private Integer listId;
+
+    @Column(name = "list_order")
+    private Integer listOrder;
+
 }

--- a/src/main/java/com/todolist/enterprise/dto/TodoList.java
+++ b/src/main/java/com/todolist/enterprise/dto/TodoList.java
@@ -1,0 +1,28 @@
+package com.todolist.enterprise.dto;
+import javax.persistence.Entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Data;
+import java.util.List;
+
+@Entity
+@Table(name = "list")
+public @Data class TodoList {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "list_id")
+    private Integer listId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @OneToMany(mappedBy = "list")
+    private List<Task> tasks;
+}

--- a/src/main/java/com/todolist/enterprise/service/ITodoService.java
+++ b/src/main/java/com/todolist/enterprise/service/ITodoService.java
@@ -8,5 +8,5 @@ public interface ITodoService {
      * @param taskId a unique identifier for a recipe
      * @return the matching task, or null if no matches found
      */
-    Task getTaskById(int taskId);    
+    public Task getTaskById(int taskId);    
 }

--- a/src/main/java/com/todolist/enterprise/service/TodoService.java
+++ b/src/main/java/com/todolist/enterprise/service/TodoService.java
@@ -1,0 +1,23 @@
+package com.todolist.enterprise.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.todolist.enterprise.dao.TaskRepository;
+import com.todolist.enterprise.dto.Task;
+
+@Component
+public class TodoService implements ITodoService {
+    private final TaskRepository taskRepository;
+
+    @Autowired
+    public TodoService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public Task getTaskById(int taskId) {
+        return taskRepository.findById(taskId).get();
+    }
+    
+}

--- a/src/main/java/com/todolist/enterprise/service/TodoServiceStub.java
+++ b/src/main/java/com/todolist/enterprise/service/TodoServiceStub.java
@@ -1,9 +1,11 @@
 package com.todolist.enterprise.service;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import com.todolist.enterprise.dto.Task;
 import java.util.Date;
 
 @Component
+@Profile("test")
 public class TodoServiceStub implements ITodoService {
     @Override
     public Task getTaskById(int taskId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.jpa.hibernate.ddl-auto=none
+spring.datasource.url=jdbc:mysql://localhost:3306/todo
+spring.datasource.username=application
+spring.datasource.password=admin


### PR DESCRIPTION
In this PR I setup the basis of database connections and setup some ORM annotations on our existing dto classes.

To keep it simple to initialize the database, I set up a docker-compose.yml file that can be ran to initialize the database with the tables we need. This solution is simpler than managing the database separately because any changes are tracked here and it's one command to get it set up (assuming docker is installed on your system). Instructions for this were added to the readme.

In addition to this, to test these new changes, I updated the controller to use the new database to retrieve information under the `task/{id}` route.

![image](https://github.com/nhing17899/IT4045C-FinalProject/assets/59770778/e8a81dc3-ca73-4d01-8cf9-b51cb463c82f)
